### PR TITLE
ENT-3013: NativeHostApi changes. Update documentation

### DIFF
--- a/docs/source/rng-host.rst
+++ b/docs/source/rng-host.rst
@@ -22,17 +22,19 @@ To run the enclave in debug mode, run:
 
 .. parsed-literal::
 
-    java -Doblivium.build=Debug -jar host.jar --debug samples/rng/rng-enclave/build/enclave/Debug/enclave.signed.so
+    java -jar host.jar -m DEBUG samples/rng/rng-enclave/build/enclave/Debug/enclave.signed.so
 
 The above will hopefully load the enclave and bind port 8080, where the host will be accepting incoming gRPC
-connections to forward to the enclave. ``-Doblivium.build=Debug`` will cause the host to use native libraries with debug
-symbols, whereas ``--debug`` will cause the host to load the enclave in DEBUG mode.
+connections to forward to the enclave. ``-m DEBUG`` will cause the host to use native libraries with debug
+symbols, and to load the enclave in DEBUG mode.
 
 To run the enclave in simulation mode, run:
 
 .. parsed-literal::
 
-    java -Doblivium.build=Simulation -jar host.jar --debug samples/rng/rng-enclave/build/enclave/Simulation/enclave.signed.so
+    java -jar host.jar -m SIMULATION samples/rng/rng-enclave/build/enclave/Simulation/enclave.signed.so
+
+.. note:: In simulation mode the enclave quote is a fake one, so we there will be no roundtrip to the IAS.
 
 For more command line options run:
 
@@ -52,29 +54,29 @@ Create/run a docker image
 The ``com.r3.sgx.host`` plugin provides a way to build and publish Docker
 images embedding a pre-configured host and enclave. The rng-enclave Gradle build is configured to take
 docker-specific parameters from the environment, see ``samples/rng/rng-enclave/build.gradle``
-for details. At minimum ``REGISTRY_URL`` must be specified, this will be the base name of the image.
+for details.
 
 To build an image:
 
 .. parsed-literal::
 
-    REGISTRY_URL=\ |OBLIVIUM_CONTAINER_REGISTRY_URL| ./gradlew samples:rng:rng-enclave:buildEnclaveImageDebug
+    ./gradlew samples:rng:rng-enclave:buildEnclaveImageDebug
 
 The above will build the image
 
 .. parsed-literal::
 
-    |OBLIVIUM_CONTAINER_REGISTRY_URL|/oblivium/oblivium-rng-enclave-server-debug:|OBLIVIUM_VERSION|
+    localhost:5000/com.r3.sgx/rng-enclave-debug:|OBLIVIUM_VERSION|
 
 Note that the registry need not be running as we're merely building the image at this stage, not pushing.
 
 To run the image create a configuration file, say ``host-config-debug.yml``, this may be empty if you're happy with the
-defaults, however you will probably want to set at least ``isEnclaveDebug: true`` unless you're using a production
+defaults, however you will probably want to set at least ``enclaveLoadMode: DEBUG`` unless you're using a production
 signed enclave. Then run:
 
 .. parsed-literal::
 
-    docker run --rm -it -p 8080:8080 -v /run/aesmd:/run/aesmd -v $PWD/host-config-debug.yml:/app/config/config.yml --device=/dev/isgx |OBLIVIUM_CONTAINER_REGISTRY_URL|/oblivium/oblivium-rng-enclave-server-debug:latest
+    docker run --rm -it -p 8080:8080 -v /run/aesmd:/run/aesmd -v $PWD/host-config-debug.yml:/app/config/config.yml --device=/dev/isgx localhost:5000/com.r3.sgx/rng-enclave-debug:|OBLIVIUM_VERSION|
 
 The above will run the container with the host and enclave, mount in the config file, expose the SGX device and the
 aesmd socket to the container, and expose the bound gRPC port on 8080.
@@ -84,44 +86,7 @@ Interact with the host
 
 To interact with the host you can connect to it through gRPC. The interface:
 
-.. sourcecode:: proto
-
-    syntax = "proto2";
-
-    option java_multiple_files = true;
-    option java_package = "com.r3.sgx.enclavelethost.grpc";
-    option java_outer_classname = "EnclaveletHostApi";
-    option objc_class_prefix = "HLW";
-
-    package proto;
-
-    service EnclaveletHost {
-        // Request a signed quote of the enclave instance.
-        rpc GetEpidAttestation (GetEpidAttestationRequest) returns (GetEpidAttestationResponse);
-
-        // Establish a session with an enclave.
-        rpc OpenSession (stream ClientMessage) returns (stream ServerMessage);
-    }
-
-    message GetEpidAttestationRequest {
-    }
-
-    message GetEpidAttestationResponse {
-        required EpidAttestation attestation = 1;
-    }
-
-    message ClientMessage {
-        required bytes blob = 1;
-    }
-
-    message ServerMessage {
-        required bytes blob = 1;
-    }
-
-    message EpidAttestation {
-        required bytes ias_response = 1;
-        required string ias_certificate = 2;
-        required bytes ias_signature = 3;
-    }
+.. literalinclude:: ../../oblivium/enclavelet-host/enclavelet-host-common/src/main/proto/enclavelet-host.proto
+    :language: proto
 
 There is also a sample :ref:`rng-client` showcasing how to interact with the host.

--- a/docs/source/rng-host.rst
+++ b/docs/source/rng-host.rst
@@ -24,9 +24,9 @@ To run the enclave in debug mode, run:
 
     java -jar host.jar -m DEBUG samples/rng/rng-enclave/build/enclave/Debug/enclave.signed.so
 
-The above will hopefully load the enclave and bind port 8080, where the host will be accepting incoming gRPC
-connections to forward to the enclave. ``-m DEBUG`` will cause the host to use native libraries with debug
-symbols, and to load the enclave in DEBUG mode.
+The above will load the enclave and bind port 8080, where the host will be accepting incoming gRPC connections to
+forward to the enclave. ``-m DEBUG`` will cause the host to use native libraries with debug symbols, and to load the
+enclave in DEBUG mode.
 
 To run the enclave in simulation mode, run:
 

--- a/docs/source/sgx-gradle-host-plugin.rst
+++ b/docs/source/sgx-gradle-host-plugin.rst
@@ -43,13 +43,13 @@ here for reference:
         baseImageName = 'oblivium/enclavelet-host'
 
         // Version tag for the Oblivium host base image.
-        baseTag = '|oblivium_version|'
+        baseTag = '|OBLIVIUM_VERSION|'
 
         // Your Docker image's chosen name.
         publishImageName = '${project.group}/${project.name}'
 
         // Your Docker image's version tag.
-        publishTag = '|oblivium_version|'
+        publishTag = '|OBLIVIUM_VERSION|'
 
         // Configuration properties for your test containers.
         testing {

--- a/samples/rng/rng-enclave/src/test/kotlin/com/r3/sgx/rng/enclave/RngEnclaveTest.kt
+++ b/samples/rng/rng-enclave/src/test/kotlin/com/r3/sgx/rng/enclave/RngEnclaveTest.kt
@@ -46,7 +46,8 @@ class RngEnclaveTest {
 
         // Create the enclave itself, setting up the host with EnclaveletHostHandler(), which mirrors RngEnclave's
         // handler tree.
-        enclave = hostApi.createEnclave(EnclaveletHostHandler(attestationConfiguration), enclaveFile)
+        val handler = EnclaveletHostHandler(attestationConfiguration, exposeErrorsToEnclave = true)
+        enclave = hostApi.createEnclave(handler, enclaveFile)
     }
 
     @Test

--- a/samples/rng/rng-enclave/src/test/kotlin/com/r3/sgx/rng/enclave/RngEnclaveTest.kt
+++ b/samples/rng/rng-enclave/src/test/kotlin/com/r3/sgx/rng/enclave/RngEnclaveTest.kt
@@ -1,14 +1,9 @@
 package com.r3.sgx.rng.enclave
 
 import com.r3.sgx.core.common.*
-import com.r3.sgx.core.host.EnclaveHandle
-import com.r3.sgx.core.host.EnclaveletHostHandler
-import com.r3.sgx.core.host.EpidAttestationHostConfiguration
-import com.r3.sgx.core.host.NativeHostApi
-import com.r3.sgx.core.host.internal.Native
+import com.r3.sgx.core.host.*
 import com.r3.sgx.enclavelethost.client.Crypto
 import com.r3.sgx.testing.BytesRecordingHandler
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import java.io.File
@@ -20,7 +15,7 @@ import kotlin.test.assertEquals
 class RngEnclaveTest {
     // The SGX gradle plugin sets this property to the path of the built+signed enclave.
     private val enclaveFile = File(System.getProperty("com.r3.sgx.enclave.path"))
-
+    private val hostApi = NativeHostApi(EnclaveLoadMode.SIMULATION)
     private lateinit var enclave: EnclaveHandle<EnclaveletHostHandler.Connection>
 
     @Before
@@ -51,12 +46,7 @@ class RngEnclaveTest {
 
         // Create the enclave itself, setting up the host with EnclaveletHostHandler(), which mirrors RngEnclave's
         // handler tree.
-        enclave = NativeHostApi.createEnclave(EnclaveletHostHandler(attestationConfiguration), enclaveFile, isDebug = true)
-    }
-
-    @After
-    fun shutdown() {
-        Native.destroyEnclave(enclave.enclaveId)
+        enclave = hostApi.createEnclave(EnclaveletHostHandler(attestationConfiguration), enclaveFile)
     }
 
     @Test
@@ -85,7 +75,7 @@ class RngEnclaveTest {
 
         // Check that the measurement matches the enclave's that we wanted to load
         // First read the metadata from the enclave file
-        val metadata:              Cursor<ByteBuffer, SgxMetadata>    = NativeHostApi.readMetadata(enclaveFile)
+        val metadata:              Cursor<ByteBuffer, SgxMetadata>    = hostApi.readMetadata(enclaveFile)
         val cssBodyInMetadata:     Cursor<ByteBuffer, SgxCssBody>     = metadata[SgxMetadata.enclaveCss][SgxEnclaveCss.body]
         val measurementInMetadata: Cursor<ByteBuffer, SgxMeasurement> = cssBodyInMetadata[SgxCssBody.measurement]
         // Now get the measurement from the quote we created


### PR DESCRIPTION
@joeldudleyr3 Added you as this touches on usability. I removed `-Doblivium.build` and merged it with `--debug` into a new flag `--enclave-load-mode`/`-m` which specifies whether how to load the enclave:

| Enclave Load mode | Native libraries | DEBUG mode | Attestation roundtrip |
| --- | --- | --- | --- |
| SIMULATION | Simulation | true | false |
| DEBUG | Debug | true | true |
| RELEASE | Release | false | true |